### PR TITLE
Adding endpoints for launch/ending recipe instances.

### DIFF
--- a/brewery/urls.py
+++ b/brewery/urls.py
@@ -12,6 +12,8 @@ urlpatterns = [
     url(r"api/brewery/(?P<pk>[0-9]+)/$", views.BreweryDetailView.as_view()),
     url(r"api/brewhouse/$", views.BrewhouseListView.as_view()),
     url(r"api/brewhouse/(?P<pk>[0-9]+)/$", views.BrewhouseDetailView.as_view()),
+    url(r"api/brewhouse/launch/", views.BrewhouseLaunchView.as_view()),
+    url(r"api/brewhouse/end/", views.BrewhouseEndView.as_view()),
 
     url(r"api/beerStyle/", views.BeerStyleListView.as_view()),
     url(r"api/recipe/$", views.RecipeListView.as_view()),

--- a/joulia/http.py
+++ b/joulia/http.py
@@ -4,9 +4,14 @@
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponseBadRequest
 from django.http import HttpResponseNotFound
+from django.http import HttpResponseForbidden
 
 
 class HTTP400(Exception):
+    pass
+
+
+class HTTP403(Exception):
     pass
 
 
@@ -50,7 +55,8 @@ def get_object_or_404(model, pk):
     try:
         obj = model.objects.get(pk=pk)
     except ObjectDoesNotExist as e:
-        raise HTTP404('Object not found.') from e
+        raise HTTP404(
+            '{} instance not found.'.format(model)) from e
     else:
         return obj
 
@@ -64,6 +70,8 @@ class ConvertHTTPExceptionsMiddleware(object):
             response = self.get_response(request)
         except HTTP400 as e:
             return HttpResponseBadRequest(e)
+        except HTTP403 as e:
+            return HttpResponseForbidden(e)
         except HTTP404 as e:
             return HttpResponseNotFound(e)
 

--- a/joulia/http.py
+++ b/joulia/http.py
@@ -1,0 +1,70 @@
+"""HTTP Utility functions for getting data out of HTTP requests.
+"""
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.http import HttpResponseBadRequest
+from django.http import HttpResponseNotFound
+
+
+class HTTP400(Exception):
+    pass
+
+
+class HTTP404(Exception):
+    pass
+
+
+def get_post_value_or_400(request, key):
+    """Gets the value for a post key if it exists. If it does not, raises
+    Http400.
+
+    Args:
+        request: Django request with POST data in it.
+        key: Post key for a value in the request.POST.
+
+    Returns:
+        value for the key in the request.POST data.
+
+    Raises:
+        Http400: if the key is not in the POST data.
+    """
+    if key not in request.POST:
+        raise HTTP400('Missing {} in request.'.format(key))
+    return request.POST[key]
+
+
+def get_object_or_404(model, pk):
+    """Gets the object from the ``model`` with the provided ``pk``. If it does
+    not exist raises Http404.
+
+    Args:
+        model: The model to query against.
+        pk: The pk for the model to query.
+
+    Returns:
+        The model instance at pk.
+
+    Raises:
+        Http404: if the model instance does not exist.
+    """
+    try:
+        obj = model.objects.get(pk=pk)
+    except ObjectDoesNotExist as e:
+        raise HTTP404('Object not found.') from e
+    else:
+        return obj
+
+
+class ConvertHTTPExceptionsMiddleware(object):
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        try:
+            response = self.get_response(request)
+        except HTTP400 as e:
+            return HttpResponseBadRequest(e)
+        except HTTP404 as e:
+            return HttpResponseNotFound(e)
+
+        return response

--- a/joulia/http_test.py
+++ b/joulia/http_test.py
@@ -3,6 +3,7 @@
 
 from django.contrib.auth.models import User
 from django.http import HttpResponseBadRequest
+from django.http import HttpResponseForbidden
 from django.http import HttpResponseNotFound
 from django.http import QueryDict
 from django.test import TestCase
@@ -53,6 +54,14 @@ class ConvertHTTPExceptionsMiddleware(TestCase):
         request = Mock()
         response = middleware(request)
         self.assertEquals(type(response), HttpResponseBadRequest)
+
+    def test_403_response(self):
+        def get_response(_):
+            raise http.HTTP403()
+        middleware = http.ConvertHTTPExceptionsMiddleware(get_response)
+        request = Mock()
+        response = middleware(request)
+        self.assertEquals(type(response), HttpResponseForbidden)
 
     def test_404_response(self):
         def get_response(_):

--- a/joulia/http_test.py
+++ b/joulia/http_test.py
@@ -1,0 +1,63 @@
+"""Tests for joulia.http module.
+"""
+
+from django.contrib.auth.models import User
+from django.http import HttpResponseBadRequest
+from django.http import HttpResponseNotFound
+from django.http import QueryDict
+from django.test import TestCase
+from unittest.mock import Mock
+
+from joulia import http
+
+
+class GetPostValueOr400Test(TestCase):
+    def test_key_missing(self):
+        request = Mock()
+        request.POST = QueryDict('foo=bar')
+        with self.assertRaises(http.HTTP400):
+            http.get_post_value_or_400(request, 'bar')
+
+    def test_key_present(self):
+        request = Mock()
+        request.POST = QueryDict('foo=bar')
+        value = http.get_post_value_or_400(request, 'foo')
+        self.assertEquals(value, 'bar')
+
+
+class GetObjectOr404Test(TestCase):
+    def test_object_exists(self):
+        # Using User as a simple example, but it could be any model.
+        user = User.objects.create(username="foo")
+        got = http.get_object_or_404(User, user.pk)
+        self.assertEquals(user, got)
+
+    def test_object_does_not_exist(self):
+        # Using User as a simple example, but it could be any model.
+        with self.assertRaises(http.HTTP404):
+            http.get_object_or_404(User, 3489572934)
+
+
+class ConvertHTTPExceptionsMiddleware(TestCase):
+    def test_okay_response(self):
+        response = Mock()
+        get_response = lambda request: response
+        middleware = http.ConvertHTTPExceptionsMiddleware(get_response)
+        request = Mock()
+        self.assertIs(middleware(request), response)
+
+    def test_400_response(self):
+        def get_response(_):
+            raise http.HTTP400()
+        middleware = http.ConvertHTTPExceptionsMiddleware(get_response)
+        request = Mock()
+        response = middleware(request)
+        self.assertEquals(type(response), HttpResponseBadRequest)
+
+    def test_404_response(self):
+        def get_response(_):
+            raise http.HTTP404()
+        middleware = http.ConvertHTTPExceptionsMiddleware(get_response)
+        request = Mock()
+        response = middleware(request)
+        self.assertEquals(type(response), HttpResponseNotFound)

--- a/joulia/log_requests.py
+++ b/joulia/log_requests.py
@@ -9,8 +9,12 @@ LOGGER = logging.getLogger(__name__)
 
 
 class HeadersLoggingMiddleware(object):
-    @staticmethod
-    def process_response(request, response):
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+
         try:
             status_text = responses[response.status_code]
         except KeyError:

--- a/joulia/settings.py
+++ b/joulia/settings.py
@@ -49,7 +49,7 @@ INSTALLED_APPS = (
     'brewery',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/joulia/settings.py
+++ b/joulia/settings.py
@@ -58,6 +58,7 @@ MIDDLEWARE = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'joulia.http.ConvertHTTPExceptionsMiddleware',
     'joulia.log_requests.HeadersLoggingMiddleware',
 )
 


### PR DESCRIPTION
Somehow this dropped out of the codebase after the merge. This adds this back.

Adds an http module to help with handling exceptions and responses for generic REST APIs.